### PR TITLE
Migrate to the Worker API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-gradle-plugin`
+    alias(libs.plugins.gradleBuildInfo)
     alias(libs.plugins.gradlePluginPublish)
     alias(libs.plugins.gradleJavaConventions)
 }
@@ -12,8 +13,13 @@ description = "A Gradle plugin for generating build info as Java code."
 
 java { toolchain.languageVersion.set(JavaLanguageVersion.of(11)) }
 
+buildInfo {
+    packageName.set("com.opencastsoftware.gradle.buildinfo")
+    properties.set(mapOf("javaPoetVersion" to libs.versions.javaPoet.get()))
+}
+
 dependencies {
-    implementation(libs.javaPoet)
+    compileOnly(libs.javaPoet)
     testImplementation(libs.junitJupiter)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+gradleBuildInfo = "0.2.1"
 gradleJavaConventions = "0.1.3"
 gradlePluginPublish = "1.2.0"
 jacoco = "0.8.8"
@@ -10,5 +11,6 @@ javaPoet = { module = "com.squareup:javapoet", version.ref = "javaPoet" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 
 [plugins]
+gradleBuildInfo = { id = "com.opencastsoftware.gradle.buildinfo", version.ref = "gradleBuildInfo" }
 gradleJavaConventions = { id = "com.opencastsoftware.gradle.java-conventions", version.ref = "gradleJavaConventions" }
 gradlePluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePluginPublish" }

--- a/src/main/java/com/opencastsoftware/gradle/buildinfo/BuildInfoExtension.java
+++ b/src/main/java/com/opencastsoftware/gradle/buildinfo/BuildInfoExtension.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2022-2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2022-2023 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.gradle.buildinfo;

--- a/src/main/java/com/opencastsoftware/gradle/buildinfo/BuildInfoPlugin.java
+++ b/src/main/java/com/opencastsoftware/gradle/buildinfo/BuildInfoPlugin.java
@@ -1,15 +1,17 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2022-2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2022-2023 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.gradle.buildinfo;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 import java.io.File;
@@ -17,54 +19,98 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class BuildInfoPlugin implements Plugin<Project> {
+    private static final String JAVAPOET_MAVEN_COORD = "com.squareup:javapoet:" + BuildInfo.javaPoetVersion;
+
     public void apply(Project project) {
-        project.getPlugins().withType(JavaPlugin.class, javaPlugin -> {
-            BuildInfoExtension extension = project.getExtensions()
-                    .create("buildInfo", BuildInfoExtension.class);
-
-            Path buildDir = project.getBuildDir().toPath();
-
-            List<String> destDirFolders = Arrays.asList(
-                    "generated", "sources", "buildinfo", "java", "main");
-
-            String destDirName = destDirFolders.stream().collect(Collectors.joining(File.separator));
-
-            Path destDir = buildDir.resolve(destDirName);
-
-            SourceSetContainer sourceSets = project.getExtensions()
-                    .getByType(SourceSetContainer.class);
-
-            SourceDirectorySet mainJavaSources = sourceSets
-                    .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-                    .getJava();
-
-            Set<File> mainSourceDirs = mainJavaSources.getSrcDirs();
-            mainSourceDirs.add(destDir.toFile());
-            mainJavaSources.setSrcDirs(mainSourceDirs);
-
-            TaskProvider<GenerateBuildInfo> generateBuildInfoTask = project.getTasks()
-                    .register("generateBuildInfo", GenerateBuildInfo.class, task -> {
-                        task.getPackageName()
-                                .set(extension.getPackageName());
-
-                        task.getClassName()
-                                .set(extension.getClassName().convention("BuildInfo"));
-
-                        task.getProperties()
-                                .set(extension.getProperties().convention(Collections.emptyMap()));
-
-                        task.getOutputDirectory()
-                                .set(destDir.toFile());
-                    });
-
-            project.getTasks()
-                    .getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME)
-                    .dependsOn(generateBuildInfoTask);
+        project.getPlugins().withType(JavaBasePlugin.class, javaPlugin -> {
+            Configuration buildInfo = configureConfigurations(project);
+            BuildInfoExtension extension = createExtension(project);
+            Path destDir = getDestinationDirectory(project);
+            SourceSet mainSourceSet = configureSourceSet(project, destDir);
+            configureBuildInfoTask(project, buildInfo, extension, mainSourceSet, destDir);
         });
+    }
 
+    private Configuration configureConfigurations(Project project) {
+        return project.getConfigurations()
+                .create("buildInfo", config -> {
+                    config.setVisible(false);
+                    config.setCanBeConsumed(false);
+                    config.setCanBeResolved(true);
+                    config.setDescription(
+                            "Dependencies of the gradle-build-info plugin.");
+                    config.defaultDependencies(
+                            deps -> deps.add(project.getDependencies().create(JAVAPOET_MAVEN_COORD)));
+                });
+    }
+
+    private BuildInfoExtension createExtension(Project project) {
+        return project.getExtensions().create("buildInfo", BuildInfoExtension.class);
+    }
+
+    private Path getDestinationDirectory(Project project) {
+        Path buildDir = project.getBuildDir().toPath();
+
+        List<String> destDirFolders = Arrays.asList(
+                "generated", "sources", "buildinfo", "java", "main");
+
+        String destDirName = destDirFolders.stream()
+                .collect(Collectors.joining(File.separator));
+
+        return buildDir.resolve(destDirName);
+    }
+
+    private SourceSet configureSourceSet(Project project, Path destDir) {
+        SourceSetContainer sourceSets = project.getExtensions()
+                .getByType(SourceSetContainer.class);
+
+        SourceSet mainSourceSet = sourceSets
+                .getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+
+        SourceDirectorySet mainJavaSources = mainSourceSet.getJava();
+
+        mainJavaSources.getSrcDirs().add(destDir.toFile());
+
+        return mainSourceSet;
+    }
+
+    private void configureBuildInfoTask(
+            Project project,
+            Configuration buildInfo,
+            BuildInfoExtension extension,
+            SourceSet mainSourceSet,
+            Path destDir) {
+        TaskContainer tasks = project.getTasks();
+
+        TaskProvider<GenerateBuildInfo> generateBuildInfoTask = tasks.register(
+                "generateBuildInfo",
+                GenerateBuildInfo.class,
+                task -> {
+                    task.getTaskClasspath()
+                            .from(buildInfo);
+
+                    task.getPackageName()
+                            .set(extension.getPackageName());
+
+                    task.getClassName()
+                            .set(extension.getClassName().convention("BuildInfo"));
+
+                    task.getProperties()
+                            .set(extension.getProperties().convention(Collections.emptyMap()));
+
+                    task.getOutputDirectory()
+                            .set(destDir.toFile());
+                });
+
+        tasks.getByName(mainSourceSet.getCompileJavaTaskName())
+                .dependsOn(generateBuildInfoTask);
+
+        if (tasks.getNames().contains(mainSourceSet.getSourcesJarTaskName())) {
+            tasks.getByName(mainSourceSet.getSourcesJarTaskName())
+                    .dependsOn(generateBuildInfoTask);
+        }
     }
 }

--- a/src/main/java/com/opencastsoftware/gradle/buildinfo/BuildInfoWorkParameters.java
+++ b/src/main/java/com/opencastsoftware/gradle/buildinfo/BuildInfoWorkParameters.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText:  © 2023 Opencast Software Europe Ltd <https://opencastsoftware.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.opencastsoftware.gradle.buildinfo;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.workers.WorkParameters;
+
+public interface BuildInfoWorkParameters extends WorkParameters {
+    @Input
+    @Optional
+    abstract public Property<String> getPackageName();
+
+    @Input
+    abstract public Property<String> getClassName();
+
+    @Input
+    abstract public MapProperty<String, String> getProperties();
+
+    @OutputDirectory
+    abstract public RegularFileProperty getOutputDirectory();
+}

--- a/src/main/java/com/opencastsoftware/gradle/buildinfo/GenerateBuildInfo.java
+++ b/src/main/java/com/opencastsoftware/gradle/buildinfo/GenerateBuildInfo.java
@@ -1,28 +1,26 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2022-2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.gradle.buildinfo;
 
-import com.squareup.javapoet.FieldSpec;
-import com.squareup.javapoet.JavaFile;
-import com.squareup.javapoet.TypeSpec;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutor;
 
-import javax.lang.model.element.Modifier;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
+import javax.inject.Inject;
 
 public abstract class GenerateBuildInfo extends DefaultTask {
+    @InputFiles
+    abstract public ConfigurableFileCollection getTaskClasspath();
+
     @Input
+    @Optional
     abstract public Property<String> getPackageName();
 
     @Input
@@ -34,33 +32,20 @@ public abstract class GenerateBuildInfo extends DefaultTask {
     @OutputDirectory
     abstract public RegularFileProperty getOutputDirectory();
 
+    @Inject
+    abstract public WorkerExecutor getWorkerExecutor();
+
     @TaskAction
-    public void generate() throws IOException {
-        String className = getClassName().get();
-        String packageName = getPackageName().get();
-        Map<String, String> properties = getProperties().get();
-        File outputDirectory = getOutputDirectory().get().getAsFile();
+    public void generate() {
+        WorkQueue workQueue = getWorkerExecutor().classLoaderIsolation(workerSpec -> {
+            workerSpec.getClasspath().from(getTaskClasspath());
+        });
 
-        TypeSpec.Builder classBuilder = TypeSpec
-                .classBuilder(className)
-                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
-
-        for (Map.Entry<String, String> property : properties.entrySet()) {
-            String propertyName = property.getKey();
-            String propertyValue = property.getValue();
-
-            FieldSpec fieldSpec = FieldSpec
-                    .builder(String.class, propertyName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-                    .initializer("$S", propertyValue)
-                    .build();
-
-            classBuilder.addField(fieldSpec);
-        }
-
-        JavaFile buildInfoFile = JavaFile
-                .builder(packageName, classBuilder.build())
-                .build();
-
-        buildInfoFile.writeTo(outputDirectory);
+        workQueue.submit(GenerateBuildInfoAction.class, parameters -> {
+            parameters.getPackageName().set(getPackageName());
+            parameters.getClassName().set(getClassName());
+            parameters.getProperties().set(getProperties());
+            parameters.getOutputDirectory().set(getOutputDirectory());
+        });
     }
 }

--- a/src/main/java/com/opencastsoftware/gradle/buildinfo/GenerateBuildInfoAction.java
+++ b/src/main/java/com/opencastsoftware/gradle/buildinfo/GenerateBuildInfoAction.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText:  © 2022-2023 Opencast Software Europe Ltd <https://opencastsoftware.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.opencastsoftware.gradle.buildinfo;
+
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.TypeSpec;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.internal.UncheckedException;
+import org.gradle.workers.WorkAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.lang.model.element.Modifier;
+
+import java.io.IOException;
+import java.util.Map;
+
+public abstract class GenerateBuildInfoAction implements WorkAction<BuildInfoWorkParameters> {
+    private final Logger logger = LoggerFactory.getLogger(GenerateBuildInfoAction.class);
+
+    @Override
+    public void execute() {
+        Property<String> packageName = getParameters().getPackageName();
+        Property<String> className = getParameters().getClassName();
+        MapProperty<String, String> properties = getParameters().getProperties();
+        RegularFileProperty outputDirectory = getParameters().getOutputDirectory();
+
+        if (packageName.getOrNull() == null) {
+            logger.warn(
+                    "The gradle-build-info plugin is enabled, but no package name has been defined for the generated code. "
+                            + "No build info code will be generated.");
+            return;
+        }
+
+        TypeSpec.Builder classBuilder = TypeSpec
+                .classBuilder(className.get())
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+
+        for (Map.Entry<String, String> property : properties.get().entrySet()) {
+            String propertyName = property.getKey();
+            String propertyValue = property.getValue();
+
+            FieldSpec fieldSpec = FieldSpec
+                    .builder(String.class, propertyName, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                    .initializer("$S", propertyValue)
+                    .build();
+
+            classBuilder.addField(fieldSpec);
+        }
+
+        JavaFile buildInfoFile = JavaFile
+                .builder(packageName.get(), classBuilder.build())
+                .build();
+
+        try {
+            buildInfoFile.writeTo(outputDirectory.get().getAsFile());
+        } catch (IOException e) {
+            UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+}

--- a/src/test/java/com/opencastsoftware/gradle/buildinfo/BuildInfoPluginTest.java
+++ b/src/test/java/com/opencastsoftware/gradle/buildinfo/BuildInfoPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2022-2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2022-2023 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.gradle.buildinfo;


### PR DESCRIPTION
This migrates the plugin to use the Gradle Worker API to generate code, enabling the use of an isolated classpath for Java dependencies.