### PR TITLE
Set the maximum Gradle version to 8.5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchPackageNames": "gradle",
-      "allowedVersions": "<8"
+      "allowedVersions": "<8.6"
     }
   ]
 }


### PR DESCRIPTION
Our dependencies (specifically gradle-maven-publish-plugin) are starting to enforce a minimum Gradle version of 8.5.